### PR TITLE
[WIP] Fix overflow when generating >150 payous

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(asicseer-pool, 1.0.10, https://github.com/cculianu/asicseer-pool)
+AC_INIT(asicseer-pool, 1.0.11, https://github.com/cculianu/asicseer-pool)
 
 AC_CANONICAL_SYSTEM
 AC_CONFIG_MACRO_DIR([m4])

--- a/src/jansson-2.10/src/strbuffer.c
+++ b/src/jansson-2.10/src/strbuffer.c
@@ -20,7 +20,7 @@
 
 #define STRBUFFER_MIN_SIZE  4096
 #define STRBUFFER_FACTOR    2
-#define STRBUFFER_SIZE_MAX  ((size_t)-1)
+#define STRBUFFER_SIZE_MAX  ((size_t)-1L)
 
 int strbuffer_init(strbuffer_t *strbuff)
 {
@@ -74,7 +74,7 @@ int strbuffer_append_bytes(strbuffer_t *strbuff, const char *data, size_t size)
     /* Leave room for EOL and NULL bytes */
     if(size + 2 > strbuff->size - strbuff->length)
     {
-	int backoff = 1;
+        useconds_t backoff = 1U;
         size_t new_size;
         char *new_value;
 
@@ -91,7 +91,7 @@ int strbuffer_append_bytes(strbuffer_t *strbuff, const char *data, size_t size)
 		new_value = realloc(strbuff->value, new_size);
 		if (new_value)
 			break;
-		usleep(backoff * 1000);
+		usleep(backoff * 1000U);
 		backoff <<= 1;
 	}
 

--- a/src/jansson-2.10/src/strbuffer.h
+++ b/src/jansson-2.10/src/strbuffer.h
@@ -8,10 +8,15 @@
 #ifndef STRBUFFER_H
 #define STRBUFFER_H
 
+#include <stdint.h>
 #include <stdlib.h>
 
 typedef struct {
-    char *value;
+    union {
+        char    *value;
+        uint8_t *uvalue;
+        void    *data;
+    };
     size_t length;   /* bytes used */
     size_t size;     /* bytes allocated */
 } strbuffer_t;

--- a/src/libasicseerpool.c
+++ b/src/libasicseerpool.c
@@ -1463,7 +1463,7 @@ void *_ckzrealloc(void *oldbuf, size_t len, bool zeromem, const char *file, cons
 		}
 		cksleep_ms(backoff);
 		backoff <<= 1;
-		if (unlikely(!backoff))
+		if (unlikely(backoff <= 0))
 			// overflow past end, start over -- this is here for correctness but should never
 			// happen in practice as it indicates we have been sleeping for 2 million seconds
 			backoff = 1;
@@ -1875,6 +1875,29 @@ int get_sernumber(uchar *s)
 		return 0;
 	memcpy(&val, &s[1], len);
 	return le32toh(val);
+}
+
+int write_compact_size(void *dest, size_t nSize)
+{
+	uint8_t *buf = (uint8_t *)dest;
+	if (nSize < 253) {
+		*buf = (uint8_t)nSize;
+		return 1;
+	}
+	if (nSize <= UINT16_MAX) {
+		*buf++ = 0xfd;
+		*(uint16_t *)buf = htole16((uint16_t)nSize);
+		return 3;
+	}
+	if (nSize <= UINT32_MAX) {
+		*buf++ = 0xfe;
+		*(uint32_t *)buf = htole32((uint32_t)nSize);
+		return 5;
+	}
+	// 64-bit (8 byte) .. unlikely.
+	*buf++ = 0xff;
+	*(uint64_t *)buf = htole64((uint64_t)nSize);
+	return 9;
 }
 
 /* For testing a le encoded 256 byte hash against a target */

--- a/src/libasicseerpool.c
+++ b/src/libasicseerpool.c
@@ -1886,17 +1886,23 @@ int write_compact_size(void *dest, size_t nSize)
 	}
 	if (nSize <= UINT16_MAX) {
 		*buf++ = 0xfd;
-		*(uint16_t *)buf = htole16((uint16_t)nSize);
+		// avoid unaligned access
+		const uint16_t datum = htole16((uint16_t)nSize);
+		memcpy(buf, &datum, 2);
 		return 3;
 	}
 	if (nSize <= UINT32_MAX) {
 		*buf++ = 0xfe;
-		*(uint32_t *)buf = htole32((uint32_t)nSize);
+		// avoid unaligned access
+		const uint32_t datum = htole32((uint32_t)nSize);
+		memcpy(buf, &datum, 4);
 		return 5;
 	}
 	// 64-bit (8 byte) .. unlikely.
 	*buf++ = 0xff;
-	*(uint64_t *)buf = htole64((uint64_t)nSize);
+	// avoid unaligned access
+	const uint64_t datum = htole64((uint64_t)nSize);
+	memcpy(buf, &datum, 8);
 	return 9;
 }
 

--- a/src/libasicseerpool.h
+++ b/src/libasicseerpool.h
@@ -589,6 +589,11 @@ int safecmp(const char *a, const char *b);
 int safecasecmp(const char *a, const char *b, int len); // pass len < 0 to compare all
 bool cmdmatch(const char *buf, const char *cmd);
 
+/// Writes length_byte(s) + `size_to_write` to the buffer at dest.  Returns the number of bytes written,
+/// including the size byte(s). `dest` should have space for at least 9 bytes.
+/// Return value will always be <= 9.
+int write_compact_size(void *dest, size_t size_to_write);
+
 // returns 0 on address parse failure, otherwise returns length of generated CScript
 int address_to_txn(char *p2h, const char *addr, const bool script, const char *default_cashaddr_prefix);
 

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -1058,7 +1058,7 @@ static void generate_coinbase(const pool_t *ckp, workbase_t *wb)
 		assert(endpos + wb->coinb1len + wb->enonce1varlen + wb->enonce2varlen <= MAX_COINBASE_TX_LEN
 		       && "INTERNAL ERROR: coinbase tx length exceeded. FIXME!");
 		wb->coinb2len = (int)endpos;
-		assert(((size_t)wb->coinb2len) == endpos && "INTERNAL ERROR: integer overflow");
+		assert(((size_t)wb->coinb2len) == endpos && wb->coinb2len > -1 && "INTERNAL ERROR: integer overflow");
 		uint8_t *compact_size_buf = alloca(9);
 		const int nb = write_compact_size(compact_size_buf, num_txns);
 		if (unlikely(nb > compact_size_reserved)) {

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -924,7 +924,7 @@ static void generate_coinbase(const pool_t *ckp, workbase_t *wb)
 	memcpy(wb->coinb2bin + wb->coinb2len, "\xff\xff\xff\xff", 4); // sequence
 	wb->coinb2len += 4;
 
-	// at this pint wb->coinb2bin[wb->coinb2len] points to the vtx.out length field (compact size).
+	// at this pint wb->coinb2bin[wb->coinb2len] points to the tx.vout length field (compact size).
 	// reserve 3 bytes for this field.  Common case is we will have to move the data back by 2 bytes, however.
 	const int compact_size_pos = wb->coinb2len;
 	static const int compact_size_reserved = 3;

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -1107,7 +1107,7 @@ static void generate_coinbase(const pool_t *ckp, workbase_t *wb)
 				memmove(wb->coinb2bin + compact_size_pos + 1, wb->coinb2bin + first_tx_pos, blob_size);
 				endpos -= ndiff;
 				wb->coinb2len -= ndiff;
-				LOGDEBUG("Coinb2 moved %d blob backwards by %d bytes, endpos now: %d",
+				LOGDEBUG("Coinb2 moved %d-byte blob backwards by %d bytes, endpos now: %d",
 				         blob_size, ndiff, wb->coinb2len);
 			}
 			first_tx_pos -= ndiff;
@@ -1116,6 +1116,7 @@ static void generate_coinbase(const pool_t *ckp, workbase_t *wb)
 			// this should never happen.
 			quit(1, "Unexpected compact_size number of bytes!");
 		}
+		LOGDEBUG("num_txs: %lu", num_txns);
 	}
 	wb->coinb2len += 4; // Blank lock
 

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -767,10 +767,10 @@ static int64_t add_user_generation(sdata_t *sdata, workbase_t *wb, txns_buffer_t
 		}
 		json_set_double(payout_entries, user->username, total_reward / (double)SATOSHIS);
 		if (credit)
-			LOGINFO("User %s reward %"PRIu64" + %"PRId64 " fee discount credit (%0.2f%% fee discount)",
-			        user->username, reward, credit, user->fee_discount * 100.0);
+			LOGINFO("User %s reward %"PRIu64" + %"PRId64 " fee discount credit (%0.2f%% fee discount) = %1.8f total",
+			        user->username, reward, credit, user->fee_discount * 100.0, total_reward / (double)SATOSHIS);
 		else
-			LOGINFO("User %s reward %"PRIu64, user->username, total_reward);
+			LOGINFO("User %s reward %1.8f", user->username, total_reward / (double)SATOSHIS);
 
 		/* Add the user's coinbase reward, using the cached cscript */
 		amt_pos = _add_txnbin(txns, total_reward, user->txnbin, user->txnlen);

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -931,8 +931,8 @@ static void generate_coinbase(const pool_t *ckp, workbase_t *wb)
 	wb->coinb2len += compact_size_reserved; // point past the reserved space.
 	int first_tx_pos = wb->coinb2len;
 
-	// Now we "give" wb->coinb2bin to the txns_buffer, which may end up modifying the pointer's destination
-	// as it grows the buffer.
+	// Now we "give" wb->coinb2bin to the txns_buffer, which may end up modifying the pointed-to buffer
+	// address as it grows the buffer.
 	txns_buffer_give(&txns_buf, (void **)&wb->coinb2bin, wb->coinb2len, COINB2_INITIAL_CAPACITY);
 	// NOTE: wb->coinb2bin will be temporarily NULL now until we "take" the buffer back.
 
@@ -1055,7 +1055,8 @@ static void generate_coinbase(const pool_t *ckp, workbase_t *wb)
 		size_t endpos, cap;
 		txns_buffer_take(&txns_buf, (void **)&wb->coinb2bin, &endpos, &cap);
 		LOGDEBUG("Coinb2 taken, endpos: %lu cap: %lu", endpos, cap);
-		assert(endpos + wb->coinb1len <= MAX_COINBASE_TX_LEN && "INTERNAL ERROR: coinbase tx length exceeded. FIXME!");
+		assert(endpos + wb->coinb1len + wb->enonce1varlen + wb->enoncevar2len <= MAX_COINBASE_TX_LEN
+		       && "INTERNAL ERROR: coinbase tx length exceeded. FIXME!");
 		wb->coinb2len = (int)endpos;
 		assert(((size_t)wb->coinb2len) == endpos && "INTERNAL ERROR: integer overflow");
 		uint8_t *compact_size_buf = alloca(9);

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -54,8 +54,8 @@ static const double nonces = 4294967296;
 #define DERP_DUST	5460 /* Minimum DERP to get onto payout list */
 #define PAYOUT_DUST	DUST_LIMIT_SATS /* Minimum payout not dust -- currently 546 sats */
 #define DERP_SPACE	1000 /* Minimum derp to warrant leaving coinbase space */
-#define PAYOUT_USERS	1000 /* Number of top users that get reward each block */
-#define PAYOUT_REWARDS	1500 /* Max number of users rewarded each block */
+#define PAYOUT_USERS    1000 /* Number of top users that get reward each block */
+#define PAYOUT_REWARDS  1500 /* Max number of users rewarded each block */
 #define SATOSHIS	100000000 /* Satoshi to a BTC */
 #if PAYOUT_REWARDS * CBGENLEN > MAX_CB_SPACE
 #error Please set PAYOUT_REWARDS to fit inside a coinbase tx (MAX_CB_SPACE)!

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -1055,7 +1055,7 @@ static void generate_coinbase(const pool_t *ckp, workbase_t *wb)
 		size_t endpos, cap;
 		txns_buffer_take(&txns_buf, (void **)&wb->coinb2bin, &endpos, &cap);
 		LOGDEBUG("Coinb2 taken, endpos: %lu cap: %lu", endpos, cap);
-		assert(endpos + wb->coinb1len + wb->enonce1varlen + wb->enoncevar2len <= MAX_COINBASE_TX_LEN
+		assert(endpos + wb->coinb1len + wb->enonce1varlen + wb->enonce2varlen <= MAX_COINBASE_TX_LEN
 		       && "INTERNAL ERROR: coinbase tx length exceeded. FIXME!");
 		wb->coinb2len = (int)endpos;
 		assert(((size_t)wb->coinb2len) == endpos && "INTERNAL ERROR: integer overflow");

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -1064,9 +1064,10 @@ static void generate_coinbase(const pool_t *ckp, workbase_t *wb)
 		if (unlikely(nb > compact_size_reserved)) {
 			quit(1, "INTERNAL ERROR: Got %lu txs in coinbase! This is unsupported!", num_txns);
 		} else if (nb == compact_size_reserved) {
-			// yay. exact match. just copy the compact size
+			// >= 253 txns. this is what we assumed as worst-case and we don't need to realign the data.
 			memcpy(wb->coinb2bin + compact_size_pos, compact_size_buf, nb);
 		} else if (nb == 1) {
+			// < 253 txns, we need to slide the tx data blob backwards by 2 bytes.
 			const int blob_size = wb->coinb2len - first_tx_pos;
 			const int ndiff = compact_size_reserved - nb;
 			assert(blob_size >= 0);

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -1066,7 +1066,7 @@ static void generate_coinbase(const pool_t *ckp, workbase_t *wb)
 		} else if (nb == compact_size_reserved) {
 			// yay. exact match. just copy the compact size
 			memcpy(wb->coinb2bin + compact_size_pos, compact_size_buf, nb);
-		} else if (nb < compact_size_reserved) {
+		} else if (nb == 1) {
 			const int blob_size = wb->coinb2len - first_tx_pos;
 			const int ndiff = compact_size_reserved - nb;
 			assert(blob_size >= 0);

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -653,7 +653,7 @@ static void txns_buffer_give(txns_buffer_t *t, void **buf, size_t pos, size_t ca
 	assert(pos <= capacity);
 
 	memset(t, 0, sizeof(*t));
-	t->buffer.data = (char *)*buf;
+	t->buffer.data = *buf;
 	*buf = NULL;
 	t->buffer.length = pos;
 	t->buffer.size = capacity;


### PR DESCRIPTION
There were bugs from ck's original code.  Bugs fixed:

- Support up to 65536 payout outputs (in practice anything above 2k payouts gets slow because of the way the stratum protocol sends the entire coinbase tx to the miners :/). 
- Set default `PAYOUT_USERS` to 1000 and `PAYOUT_REWARDS` to 1500.  `PAYOUT_REWARDS` determines the maximum number of user payouts in the coinbase tx.  So we have a maximum of 1500 now (as opposed to the old max of 150). TODO: Make the actual value used configurable from the conf file.
- Added `write_compact_size` to properly serialize sizes to bitcoin data streams.
- Con Kolivas initially assumed 33 bytes for a txout.  It's actually 34.
- Out txn generation code now dynamically resizes the buffer it's writing to using the Janssen `strbuffer_t` API to manage/realloc the buffer.  This should avoid potential issues with the coinbase buffer not having been allocated to be large enough (which was what was crashing the program before).
- Cleaned up the code a bit
- Bumped version to 1.0.11
