### PR TITLE
Add SOLO mining mode (-B / --solo) + README updates

### DIFF
--- a/README
+++ b/README
@@ -38,6 +38,7 @@ It has been updated and reworked to add features and to support Bitcoin Cash
 * Added ZMQ support for new block notifications
 * Removed asicseer-db, removed all sql, HTML, & php files related to this.
 * Updated source tree to use cmake, removed autotools-based build.
+* Added optional "solo" mining mode (-B / --solo).
 * Fixed bugs
 
 BUILDING
@@ -123,47 +124,10 @@ Features:
 
 
 ---
-BUILDING:
-
-** NOTE from Calin: The below is no longer accurate since we switched the
-** codebase to use cmake instead of autotools.
-
-Building asicseer-pool standalone without asicseer-db has no dependencies
-outside of the basic build tools on any Linux installation.
-
-sudo apt-get install build-essential yasm libzmq3-dev
-./configure --without-asicseer-db
-make
-
-
-** NOTE from Calin: The below is no longer accurate since we have removed
-** asicseer-db.
-
-Building with asicseer-db requires installation of the postgresql, gsl and ssl
-development libraries.
-
-sudo apt-get install build-essential yasm libzmq3-dev libpq-dev libgsl-dev
-./configure --with-asicseer-db
-make
-
-older distributions may instead require a different version of gsl:
- sudo apt-get install build-essential libpq-dev libgsl0ldbl libgsl0-dev yasm
-
-N.B.: asicseer-db also requires libssl-dev but libpq-dev depends on it and
-      installs it.
-
-
-Building from git also requires autoconf and automake
-
-sudo apt-get install build-essential yasm libzmq3-dev libpq-dev libgsl-dev autoconf automake libtool
-./autogen.sh
-./configure
-make
-
+BUILT BINARIES:
 
 Binaries will be built in the src/ subdirectory. Binaries generated will be:
 asicseer-pool - The main pool back-end.
-asicseer-db   - The pool's database (only if ./configure --with-asicseer-db).
 asicseer-pmsg - An application for passing messages in libasicseerpool format
                 to asicseer-pool/asicseer-db.
 notifier      - An application designed to be run with bitcoind's -blocknotify
@@ -174,25 +138,16 @@ notifier      - An application designed to be run with bitcoind's -blocknotify
 
 
 Installation is NOT required and asicseer-pool can be run directly from the
-directory it's built in but it can be installed with:
-sudo make install
-
-
-It is anticipated that pool operators wishing to set up a full database based
-installation of asicseer-pool+asicseer-db will be familiar with setting up
-postgresql and associated permissions to the directories where the various
-processes will communicate with each other and a web server so these will not be
-documented.
-
+directory it's built in.
 
 ---
 RUNNING:
 
 asicseer-pool supports the following options:
 
--A | --standalone
+-A | --standalone (unused)
+-B | --solo
 -c CONFIG | --config CONFIG
--d DB-NAME | --db-name DB-NAME
 -g GROUP | --group GROUP
 -H | --handover
 -h | --help
@@ -210,11 +165,13 @@ asicseer-pool supports the following options:
 -v | --version
 
 
--A Standalone mode tells asicseer-pool not to try to communicate with
-asicseer-db or log any asicseer-db requests in the rotating db logs it would
-otherwise store. All users are automatically accepted without any attempt to
-authorize users in any way. This option is explicitly enabled when built without
-db support.
+-A Standalone mode (defunct). This option currently does nothing but used
+to tell the program not to use asicseer-db. It only exists now for backward
+compatibility from e.g. extant shell scripts, etc.
+
+-B Solo mining mode. Payouts will give all of the reward (minus fees) to the
+miner that solved the block. Use this if you intend to run a solo mining pool.
+This option does not workwith any of the following: -N, -P, -p, -R, -u.
 
 -c <CONFIG> tells asicseer-pool to override its default configuration filename
 and load the specified one. If -c is not specified, asicseer-pool looks for:
@@ -287,28 +244,6 @@ upstream pool specified in the configuration file and then reconnect miners to
 mine with their chosen username/password to the upstream pool.
 
 -v Prints the program version and exits immediately.
-
-
-asicseer-db takes the following options:
-
--b DBPREFIX | --dbprefix DBPREFIX
--c CONFIG | --config CONFIG
--d DBNAME | --dbname DBNAME
--h | --help
--k | --killold
--l LOGLEVEL | --loglevel LOGLEVEL
--n NAME | --name NAME
--p DBPASS | --dbpass DBPASS
--r POOL-LOGDIR | --pool-logdir POOL-LOGDIR
--R LOGDIR | --logdir LOGDIR
--s SOCKDIR | --sockdir SOCKDIR
--u DBUSER | --dbuser DBUSER
--v | --version
--y | --confirm
--Y CONFIRMRANGE | --confirmrange CONFIRMRANGE
-
-
-ckpmsg and notifier support the -n, -p and -s options
 
 ---
 CONFIGURATION

--- a/README
+++ b/README
@@ -167,11 +167,13 @@ asicseer-pool supports the following options:
 
 -A Standalone mode (defunct). This option currently does nothing but used
 to tell the program not to use asicseer-db. It only exists now for backward
-compatibility from e.g. extant shell scripts, etc.
+compatibility.
 
 -B Solo mining mode. Payouts will give all of the reward (minus fees) to the
 miner that solved the block. Use this if you intend to run a solo mining pool.
-This option does not workwith any of the following: -N, -P, -p, -R, -u.
+This option does not work with any of the following: -N, -P, -p, -R, -u.
+** Note ** In solo mining mode, all miner clients must have valid BCH addresses
+as their username prefix otherwise they will be rejected.
 
 -c <CONFIG> tells asicseer-pool to override its default configuration filename
 and load the specified one. If -c is not specified, asicseer-pool looks for:

--- a/src/asicseer-pool.c
+++ b/src/asicseer-pool.c
@@ -2131,8 +2131,8 @@ int main(int argc, char **argv)
         }
     }
 
-    if (ckp.proxy && ckp.solo) {
-        quit(1, "Cannot set both proxy and solo mode");
+    if ((ckp.proxy || ckp.node || ckp.passthrough || ckp.redirector || ckp.remote) && ckp.solo) {
+        quit(1, "Solo mode requires stand-alone/non-proxy/non-redirector/non-passhtrough/non-node mode.");
     }
 
     if (ckp.daemon) {
@@ -2315,6 +2315,9 @@ int main(int argc, char **argv)
     for (int i = 0; i < ckp.n_bchsigs; ++i) {
         if (ckp.bchsigs[i].sig && *ckp.bchsigs[i].sig)
             LOGNOTICE("Using coinbase signature #%d: %s", i+1, ckp.bchsigs[i].sig);
+    }
+    if (ckp.solo) {
+        LOGWARNING("Solo mode activated: miners that find a solution get the full block reward (minus pool fees)");
     }
     ckp.main.ckp = &ckp;
     ckp.main.processname = strdup("main");

--- a/src/asicseer-pool.c
+++ b/src/asicseer-pool.c
@@ -2037,7 +2037,7 @@ int main(int argc, char **argv)
         switch (c) {
             case 'A':
                 /* legacy compat. */
-                fprintf(stderr, "Warning: Since ckdb as been removed, `-A` option is always active; ignoring `-A` from command-line.\n");
+                fprintf(stderr, "Warning: Since ckdb has been removed, `-A` option is always active; ignoring `-A` from command-line.\n");
                 break;
             case 'B':
                 ckp.solo = true;

--- a/src/asicseer-pool.c
+++ b/src/asicseer-pool.c
@@ -1961,6 +1961,7 @@ static struct option long_options[] = {
     {"trusted",     no_argument,       0,    't'},
     {"userproxy",   no_argument,       0,    'u'},
     {"version",     no_argument,       0,    'v'},
+    {"solo",        no_argument,       0,    'B'},
     {0, 0, 0, 0}
 };
 
@@ -2032,10 +2033,14 @@ int main(int argc, char **argv)
         ckp.initial_args[ckp.args] = strdup(argv[ckp.args]);
     ckp.initial_args[ckp.args] = NULL;
 
-    while ((c = getopt_long(argc, argv, "Ac:Dd:g:HhkLl:Nn:PpqRS:s:tuv", long_options, &i)) != -1) {
+    while ((c = getopt_long(argc, argv, "ABc:Dd:g:HhkLl:Nn:PpqRS:s:tuv", long_options, &i)) != -1) {
         switch (c) {
             case 'A':
-                ckp.standalone = true;
+                /* legacy compat. */
+                fprintf(stderr, "Warning: Since ckdb as been removed, `-A` option is always active; ignoring `-A` from command-line.\n");
+                break;
+            case 'B':
+                ckp.solo = true;
                 break;
             case 'c':
                 ckp.config = optarg;
@@ -2083,7 +2088,7 @@ int main(int argc, char **argv)
             case 'N':
                 if (ckp.proxy || ckp.redirector || ckp.userproxy || ckp.passthrough)
                     quit(1, "Cannot set another proxy type or redirector and node mode");
-                ckp.standalone = ckp.proxy = ckp.passthrough = ckp.node = true;
+                ckp.proxy = ckp.passthrough = ckp.node = true;
                 break;
             case 'n':
                 ckp.name = optarg;
@@ -2091,7 +2096,7 @@ int main(int argc, char **argv)
             case 'P':
                 if (ckp.proxy || ckp.redirector || ckp.userproxy || ckp.node)
                     quit(1, "Cannot set another proxy type or redirector and passthrough mode");
-                ckp.standalone = ckp.proxy = ckp.passthrough = true;
+                ckp.proxy = ckp.passthrough = true;
                 break;
             case 'p':
                 if (ckp.passthrough || ckp.redirector || ckp.userproxy || ckp.node)
@@ -2104,7 +2109,7 @@ int main(int argc, char **argv)
             case 'R':
                 if (ckp.proxy || ckp.passthrough || ckp.userproxy || ckp.node)
                     quit(1, "Cannot set a proxy type or passthrough and redirector modes");
-                ckp.standalone = ckp.proxy = ckp.passthrough = ckp.redirector = true;
+                ckp.proxy = ckp.passthrough = ckp.redirector = true;
                 break;
             case 's':
                 ckp.socket_dir = strdup(optarg);
@@ -2112,7 +2117,7 @@ int main(int argc, char **argv)
             case 't':
                 if (ckp.proxy)
                     quit(1, "Cannot set a proxy type and trusted remote mode");
-                ckp.standalone = ckp.remote = true;
+                ckp.remote = true;
                 break;
             case 'u':
                 if (ckp.proxy || ckp.redirector || ckp.passthrough || ckp.node)
@@ -2124,6 +2129,10 @@ int main(int argc, char **argv)
                 exit(0);
                 break; // not reached
         }
+    }
+
+    if (ckp.proxy && ckp.solo) {
+        quit(1, "Cannot set both proxy and solo mode");
     }
 
     if (ckp.daemon) {
@@ -2219,6 +2228,10 @@ int main(int argc, char **argv)
         if (ckp.btcdnotify[i])
             ckp.n_notify_btcds++;
     }
+
+    // refuse to proceed if single_payout_override is specified and solo mode is also specified
+    if (ckp.single_payout_override && ckp.solo)
+        quit(1, "Cannot use single_payout_override mode with SOLO mode (-B)");
 
     // set up donation addresses
     {

--- a/src/asicseer-pool.h
+++ b/src/asicseer-pool.h
@@ -234,8 +234,8 @@ struct pool_instance {
     /* Are we running as a proxy */
     bool proxy;
 
-    /* Are we running without ckdb */
-    bool standalone;
+    /* Are we running in SOLO mode */
+    bool solo;
 
     /* Are we running in userproxy mode */
     bool userproxy;

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -6701,6 +6701,7 @@ out:
             wb->readcount--;
             ck_wunlock(&sdata->workbase_lock);
 
+            client_apply_mindiff_override(client); /* ensure diff respects mindiff_overrides */
             stratum_send_diff(sdata, client);
         }
     }

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -1149,6 +1149,7 @@ static void generate_coinbase(const pool_t *ckp, workbase_t *wb)
         wb->coinb2len = sizeof(t0) + 4; // timestamp (end of OP_RETURN) + nlocktime == 4 bytes of zeroes at end
         wb->coinb2bin = ckzalloc(wb->coinb2len);
         memcpy(wb->coinb2bin, &t0, sizeof(t0)); // copy timestamp to end of OP_RETURN
+        wb->solo.coinb3len = 0; // paranoia, should already be 0
     } else {
         // Handle SOLO mode here:
         // - where we *don't* write nlocktime to coinb2; instead we rely on coinb3 for the 4 empty nlocktime bytes

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -1155,7 +1155,7 @@ static void generate_coinbase(const pool_t *ckp, workbase_t *wb)
         // - where we *don't* write nlocktime to coinb2; instead we rely on coinb3 for the 4 empty nlocktime bytes
         // - we do write the t0 end of OP_RETURN
         // - we do write the amount here for the solo miner payout which must end at end of coinb2
-        wb->coinb2len = sizeof(t0) + 8; // timestamp (end of OP_RETURN) + amount for the per-user payout
+        wb->coinb2len = sizeof(t0) + 8; // timestamp (end of OP_RETURN) + amount for the miner-specific payout
         wb->coinb2bin = ckzalloc(wb->coinb2len);
         size_t offset = 0;
         memcpy(wb->coinb2bin + offset, &t0, sizeof(t0));
@@ -5992,7 +5992,8 @@ static void client_apply_mindiff_override(stratum_instance_t *client)
             // match, apply suggested_diff to client, which will clamp
             // the minimum difficulty for this client for all workers to be >= ovr->mindiff
             client->suggest_diff = client->old_diff = client->diff = ovr->mindiff;
-            LOGDEBUG("mindiff_overrides: Applied minimum & starting difficulty = %"PRId64" to client %"PRId64" matching \"%s\"", ovr->mindiff, client->id, ovr->useragent);
+            LOGDEBUG("mindiff_overrides: Applied minimum & starting difficulty = %"PRId64" to client %"PRId64" matching"
+                     " \"%s\"", ovr->mindiff, client->id, ovr->useragent);
             return;
         }
     }

--- a/src/stratifier.h
+++ b/src/stratifier.h
@@ -88,6 +88,11 @@ struct genwork {
     char *coinb2; // coinbase2
     uchar *coinb2bin;
     int coinb2len; // length of above
+    /* Solo mode only */
+    struct {
+        uchar coinb3bin[4]; // coinbase txn footer (always just 4 blank locktime bytes)
+        uint8_t coinb3len; // length of above
+    } solo;
 
     /* Cached header binary */
     char headerbin[112];


### PR DESCRIPTION
This adds a new command-line option `-B` or `--solo` which forces the pool into SOLO mining mode. In SOLO mining mode, we disable SPLNS payouts and instead each miner that solves a block gets the full reward, minus any fees + dev donation.

This is a partial backport of this feature from here: https://bitbucket.org/ckolivas/ckpool-solo , but lots of original code was added due to divergence of the codebases.

Also in this PR: Updated README.
